### PR TITLE
fix: global anchor styling scope change

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -207,6 +207,10 @@ header nav .nav-sections > ul > li.nav-drop {
   padding-right: 0;
 }
 
+header nav .nav-brand a {
+  padding: 0;
+}
+
 header nav .nav-sections ul li a,
 header nav .nav-sections ul li.nav-drop {
   height: 100%;
@@ -219,6 +223,10 @@ header nav .nav-sections ul li.nav-drop {
   transition-property: color,background-color,border-color;
   transition-duration: .2s;
   transition-timing-function: linear;
+  font-family: var(--nav-font-family);
+  font-size: var(--body-font-size-s);
+  font-weight: var(--nav-dropdown-element-font-weight);
+  padding: 0;
 }
 
 header nav .nav-sections > ul > li.active > a,

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -207,10 +207,6 @@ header nav .nav-sections > ul > li.nav-drop {
   padding-right: 0;
 }
 
-header nav .nav-brand a {
-  padding: 0;
-}
-
 header nav .nav-sections ul li a,
 header nav .nav-sections ul li.nav-drop {
   height: 100%;
@@ -223,10 +219,6 @@ header nav .nav-sections ul li.nav-drop {
   transition-property: color,background-color,border-color;
   transition-duration: .2s;
   transition-timing-function: linear;
-  font-family: var(--nav-font-family);
-  font-size: var(--body-font-size-s);
-  font-weight: var(--nav-dropdown-element-font-weight);
-  padding: 0;
 }
 
 header nav .nav-sections > ul > li.active > a,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -351,7 +351,8 @@ body > main > div:first-child > div {
   padding-top: 75px;
 }
 
-body.home a {
+body.home > main a,
+body.home > footer a {
   box-sizing: border-box;
   cursor: pointer;
   display: inline-block;
@@ -369,25 +370,25 @@ body.home a {
   transition-duration: .2s;
   transition-property: all;
   transition-timing-function: ease;
-  white-space: nowrap; 
+  white-space: nowrap;
 }
 
 .section.dark {
   background-color: var(--secondary-background-color);
   color: var(--secondary-text-color);
-  padding-bottom: 65px;    
+  padding-bottom: 65px;
 }
 
 .section.dark.center {
-  text-align: center; 
+  text-align: center;
 }
 
 .section.dark.center h2 {
-  text-align: center; 
+  text-align: center;
 }
 
 .section.dark a {
-  color: var(--primary-color-active);    
+  color: var(--primary-color-active);
 }
 
 body.home .section a {


### PR DESCRIPTION
Global anchor styling should not be applied to `body header` because `header` has a different set of anchor styling rules compared to `main` and `footer`

This PR makes the scope of global anchor styling rules narrower

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--elco-aerotop-sg--hlxsites.hlx.page/de/
- After: https://navbar-styling-override--elco-aerotop-sg--hlxsites.hlx.page/de/
