### PR TITLE
 Fixing footer with different behaviour in different languages.

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -42,10 +42,18 @@ footer {
 }
 
 .footer a {
-  font-size: var(--body-font-size-s);
+  cursor: pointer;
+  font-family: var(--body-font-family);
+  font-size: var(--button-font-size);
+  font-style: normal;
+  line-height: var(--button-line-height);
+  margin: 0;
+  overflow: hidden;
+  text-align: center;
   text-decoration: none;
-  color: var(--secondary-color);
   text-transform: uppercase;
+  color: var(--secondary-color);
+  padding: 0;
 }
 
 .footer a:hover {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -382,8 +382,7 @@ body > main > div:first-child > div {
   padding-top: 75px;
 }
 
-body.home > main a,
-body.home > footer a {
+body.home > main a {
   box-sizing: border-box;
   cursor: pointer;
   display: inline-block;


### PR DESCRIPTION
A padding in the a attribute was removed as it didn't need to be there, this caused the different behaviour in german and english where the main style wasn't added

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #31
Fix #64

Test URLs:
- Before: https://main--elco-aerotop-sg--hlxsites.hlx.page/de/
- After: https://fix-footer--elco-aerotop-sg--hlxsites.hlx.page/de/
