### PR TITLE
fix: progress bar mobile styling

### DIFF
--- a/blocks/progress-bar-table/progress-bar-table.css
+++ b/blocks/progress-bar-table/progress-bar-table.css
@@ -8,86 +8,90 @@
   position: relative;
   width: auto
 }
-  
+
+.progress.aside > h2 {
+  margin-bottom: 0;
+}
+
 .dark .progress-aside-21-grey h2,
 .dark .progress-aside-22-grey h2 {
   color: var(--progress-bar-first-row-color)
 }
-  
+
 .dark .progress-aside-21-green h2,
 .dark .progress-aside-22-green h2 {
   color: var(--progress-bar-dark-second-row-color)
 }
-  
+
 .dark .progress-aside-21-red h2,
 .dark .progress-aside-22-red h2 {
   color: var(--primary-color-active)
 }
-  
+
 .dark .progress-aside-21-black h2,
 .dark .progress-aside-22-black h2 {
   color: var(--primary-text-color)
 }
-  
+
 .progress-aside-11-grey,
 .progress-aside-12-grey {
   color: var(--progress-bar-first-row-color);
   padding-left: 0
  }
-  
+
 .progress-aside-11-green,
 .progress-aside-12-green {
   color: var(--progress-bar-dark-second-row-color);
   padding-left: 0
 }
-  
+
 .progress-aside-11-red,
 .progress-aside-12-red {
   color: var(--primary-color-active);
   padding-left: 0
 }
-  
+
 .progress-aside-11-black,
 .progress-aside-12-black {
   color: var(--primary-text-color);
   padding-left: 0
 }
-  
+
 .progress-aside-21-grey,
 .progress-aside-22-grey {
   color: var(--progress-bar-first-row-color);
   justify-content: right
 }
-  
+
 .progress-aside-21-green,
 .progress-aside-22-green {
   color: var(--progress-bar-dark-second-row-color);
   justify-content: right
 }
-  
+
 .progress-aside-21-red,
 .progress-aside-22-red {
   color: var(--primary-color-active);
   justify-content: right
 }
-  
+
 .progress-aside-21-black,
 .progress-aside-22-black {
   color: var(--primary-text-color);
   justify-content: right
 }
-  
+
 .progress-wrapper {
   display: flex;
   flex-flow: row wrap;
   text-align: center
 }
-  
+
 .progress-wrapper>* {
   flex: 100%;
   padding: 10px
 }
-  
+
 .progress-description-1 {
   border: 0;
   color: var(--progress-bar-first-row-color);
@@ -95,25 +99,25 @@
   padding: 0;
   text-align: left
 }
-  
+
 .progress-description-2 {
   border: 0;
   margin: 0;
   padding: 0;
   text-align: left
 }
-  
+
 .progress-subtitle-1 {
   color: var(--progress-bar-first-row-color);
   padding-left: 0;
   text-align: left
 }
-  
+
 .progress-subtitle-2 {
   padding-left: 0;
   text-align: left
 }
-  
+
 .progress-value-1-grey,.progress-value-2-grey,
 .dark .progress-value-1-grey,
 .dark .progress-value-2-grey {
@@ -123,7 +127,7 @@
   transition: width 2s ease;
   width: 0
 }
-  
+
 .progress-value-1-red,.progress-value-2-red,
 .dark .progress-value-1-red,
 .dark .progress-value-2-red {
@@ -133,7 +137,7 @@
   transition: width 2s ease;
   width: 0
 }
-  
+
 .progress-value-1-green,
 .progress-value-2-green,
 .dark .progress-value-1-green,
@@ -144,7 +148,7 @@
   transition: width 2s ease;
   width: 0
 }
-  
+
 .progress-value-1-black,
 .progress-value-2-black,
 .dark .progress-value-1-black,
@@ -155,19 +159,19 @@
   transition: width 2s ease;
   width: 0
 }
-  
+
 .progress-title-1,
 .progress-title-2 {
   border-bottom: 0;
   padding: 0;
   text-align: left
 }
-  
+
 @media all and (min-width:  600px) {
   .aside {
   flex: 1 0 0
   }
-  
+
   div[class^='progress aside progress-aside-2'] {
   flex: .3 0 0
   }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #99 

Test URLs:
- Before: https://main--elco-aerotop-sg--hlxsites.hlx.page/de/
- After: https://progress-bar-mobile--elco-aerotop-sg--hlxsites.hlx.page/de/

after:

![Screen Shot 2023-02-02 at 17 48 39](https://user-images.githubusercontent.com/1171225/216389219-6f5dd20e-d431-4f5e-b1ec-c11b507cc40e.png)

![Screen Shot 2023-02-02 at 17 48 45](https://user-images.githubusercontent.com/1171225/216389204-fffa3af0-7195-444f-a6dc-e1362f185e35.png)

