### PR TITLE
Fixed padding of undecorated url in light sections

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -592,6 +592,7 @@ body.home .section.url-not-decorated a {
   text-transform: lowercase;
   font-family: var(--body-font-family);
   font-size: var(--body-font-size-m);
+  padding:0;
 }
 
 body.home .section.dark a:hover, body.home .section.dark a:focus, .section.dark button:hover, .section.dark button:focus {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -592,7 +592,7 @@ body.home .section.url-not-decorated a {
   text-transform: lowercase;
   font-family: var(--body-font-family);
   font-size: var(--body-font-size-m);
-  padding:0;
+  padding: 0;
 }
 
 body.home .section.dark a:hover, body.home .section.dark a:focus, .section.dark button:hover, .section.dark button:focus {


### PR DESCRIPTION
Please review

Fix #130

Test URLs:
- Before: https://main--elco-aerotop-sg--hlxsites.hlx.page/de/
- After: https://130-column-link--elco-aerotop-sg--hlxsites.hlx.page/de/
